### PR TITLE
Add premium plan page with fintech-themed UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Finsentiment
+
+FinSentiment provides Reddit-driven financial sentiment insights.
+
+This update introduces a refreshed fintech-inspired interface and a new
+**Premium** page outlining freemium and premium plans for power users.

--- a/SentimentStream/app.py
+++ b/SentimentStream/app.py
@@ -349,6 +349,11 @@ def stock_list():
 def about():
     return render_template('about.html')
 
+
+@app.route('/premium')
+def premium():
+    return render_template('premium.html')
+
 # Error handlers
 @app.errorhandler(404)
 def page_not_found(e):

--- a/SentimentStream/static/css/main.css
+++ b/SentimentStream/static/css/main.css
@@ -16,6 +16,11 @@
     --reddit-upvote: #d82d00;
     --reddit-downvote: #2E8B57;
     --reddit-border: #EDEFF1;
+
+    /* Fintech theme */
+    --fintech-dark: #0d1b2a;
+    --fintech-blue: #1b263b;
+    --premium-gold: #ffb703;
     
     /* Sentiment colors */
     --sentiment-positive: #2E8B57;
@@ -56,7 +61,7 @@ a:hover {
 
 /* Main layout components */
 .header {
-    background-color: var(--reddit-black);
+    background: linear-gradient(90deg, var(--fintech-dark), var(--fintech-blue));
     border-bottom: 1px solid var(--reddit-border);
     height: 48px;
     display: flex;
@@ -483,6 +488,37 @@ a:hover {
 .btn-orange:hover {
     background-color: #c03f15;
     border-color: #c03f15;
+}
+
+.btn-premium {
+    background-color: var(--premium-gold);
+    color: var(--reddit-black);
+    border-color: var(--premium-gold);
+}
+
+.btn-premium:hover {
+    background-color: #e0a800;
+    border-color: #e0a800;
+    color: var(--reddit-black);
+}
+
+.pricing-card {
+    background-color: white;
+    border: 1px solid var(--reddit-border);
+    border-radius: 8px;
+    padding: var(--space-lg);
+    text-align: center;
+}
+
+.pricing-card.premium {
+    border-color: var(--premium-gold);
+    box-shadow: 0 0 10px rgba(255, 183, 3, 0.3);
+}
+
+.pricing-title {
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-bottom: var(--space-md);
 }
 
 /* Utilities */

--- a/SentimentStream/templates/base.html
+++ b/SentimentStream/templates/base.html
@@ -42,6 +42,7 @@
             <a href="{{ url_for('trend_analysis') }}" class="btn btn-secondary" data-spinner="true" data-spinner-message="Loading trend analysis...">Trends</a>
             <a href="{{ url_for('stock_list') }}" class="btn btn-secondary" data-spinner="true" data-spinner-message="Loading stock data...">Stocks</a>
             <a href="{{ url_for('about') }}" class="btn btn-secondary" data-spinner="true">About</a>
+            <a href="{{ url_for('premium') }}" class="btn btn-premium" data-spinner="true">Go Premium</a>
         </div>
     </header>
     

--- a/SentimentStream/templates/premium.html
+++ b/SentimentStream/templates/premium.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block title %}FinSentiment Premium{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4 text-center">Choose Your Plan</h1>
+  <div class="row">
+    <div class="col-md-6 mb-4">
+      <div class="pricing-card">
+        <div class="pricing-title">Freemium</div>
+        <p>Basic access to sentiment insights and trending posts.</p>
+        <ul class="text-start">
+          <li>Community-driven discussions</li>
+          <li>Delayed market data</li>
+          <li>Limited search history</li>
+        </ul>
+      </div>
+    </div>
+    <div class="col-md-6 mb-4">
+      <div class="pricing-card premium">
+        <div class="pricing-title">Premium</div>
+        <p>Unlock advanced analytics and real-time market data.</p>
+        <ul class="text-start">
+          <li>Real-time sentiment updates</li>
+          <li>Comprehensive stock analytics</li>
+          <li>Priority support</li>
+        </ul>
+        <a href="#" class="btn btn-premium mt-2">Upgrade Now</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- introduce fintech color palette and gradient header
- add premium plan page and navigation button
- document refreshed interface in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a29ba730088330aa8bac9e25787331