### PR TITLE
Configure Render deployment for Finsentiment

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,11 +1,25 @@
+import os
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from flask_sqlalchemy import SQLAlchemy
 from reddit_fetcher import RedditFetcher
 from sentiment_analyzer import SentimentAnalyzer
 from stock_data_fetcher import StockDataFetcher
 
 app = Flask(__name__)
 CORS(app)
+
+# Get DATABASE_URL from environment
+database_url = os.environ.get('DATABASE_URL')
+
+# Adjust for deprecated postgres scheme
+if database_url and database_url.startswith("postgres://"):
+    database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+app.config['SQLALCHEMY_DATABASE_URI'] = database_url
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
 
 reddit_fetcher = RedditFetcher()
 sentiment_analyzer = SentimentAnalyzer()
@@ -43,6 +57,10 @@ def api_stocks():
             'sentiment': avg_sentiment
         })
     return jsonify(stocks)
+
+@app.route('/')
+def health_check():
+    return jsonify(status="ok"), 200
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ numpy
 nltk
 textblob
 requests
+gunicorn

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,10 @@
   <h1>Finsentiment Posts</h1>
   <div id="posts">Loading...</div>
   <script>
+    const apiUrl = 'https://finsentiment-backend.onrender.com/api/posts';
     async function loadPosts() {
       try {
-        const res = await fetch('http://localhost:5000/api/posts');
+        const res = await fetch(apiUrl);
         const posts = await res.json();
         const container = document.getElementById('posts');
         container.innerHTML = '';


### PR DESCRIPTION
## Summary
- load database config from Render `DATABASE_URL` and add health check endpoint
- serve frontend data from Render API instead of localhost
- add gunicorn to backend requirements for deployment

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5d35f6f948330953ae7ab141e0915