### PR TITLE
Add Stock model and database-backed cron job

### DIFF
--- a/backend/cron_job.py
+++ b/backend/cron_job.py
@@ -1,58 +1,89 @@
+import os
 import logging
 from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from app import app, db
-from models import Post
+# Import các Models và Fetchers
+from models import Base, Post, Stock
 from reddit_fetcher import RedditFetcher
 from sentiment_analyzer import SentimentAnalyzer
+from stock_data_fetcher import StockDataFetcher
 
+logging.basicConfig(level=logging.INFO)
 
-def fetch_and_store_posts():
-    """Fetch latest posts, analyze sentiment and store in the database."""
+# --- PHẦN KẾT NỐI DATABASE (giống như tôi đã hướng dẫn) ---
+database_url = os.environ.get('DATABASE_URL')
+if database_url and database_url.startswith("postgres://"):
+    database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+if not database_url:
+    logging.error("Error: DATABASE_URL environment variable not set.")
+    exit()
+
+engine = create_engine(database_url)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# --- HÀM XỬ LÝ POSTS ---
+def fetch_and_store_posts(db_session):
+    logging.info("Starting to fetch and store posts...")
     reddit = RedditFetcher()
     analyzer = SentimentAnalyzer()
+    posts_data = reddit.get_posts("wallstreetbets", "day", "hot", limit=50)
 
-    with app.app_context():
-        db.create_all()
-        posts = reddit.get_posts("wallstreetbets", "day", "hot", limit=25)
-        for data in posts:
-            sentiment = analyzer.analyze_text(
-                f"{data.get('title', '')} {data.get('selftext', '')}"
-            )
+    for data in posts_data:
+        sentiment = analyzer.analyze_text(f"{data.get('title', '')} {data.get('selftext', '')}")
+        created_dt = datetime.fromtimestamp(data.get("created_utc")) if data.get("created_utc") else None
 
-            created = data.get("created_utc")
-            if isinstance(created, datetime):
-                created_dt = created
-            else:
-                try:
-                    created_dt = datetime.fromtimestamp(created)
-                except Exception:  # pragma: no cover - fallback
-                    created_dt = None
+        post = Post(
+            id=data.get("id"), title=data.get("title"), selftext=data.get("selftext"),
+            url=data.get("url"), subreddit=data.get("subreddit"), author=data.get("author"),
+            created_utc=created_dt, score=data.get("score", 0), num_comments=data.get("num_comments", 0),
+            sentiment_positive=sentiment.get("pos", 0.0), sentiment_negative=sentiment.get("neg", 0.0),
+            sentiment_neutral=sentiment.get("neu", 0.0), sentiment_compound=sentiment.get("compound", 0.0),
+        )
+        db_session.merge(post)
+    logging.info(f"Merged {len(posts_data)} posts.")
 
-            post = Post(
-                id=data.get("id"),
-                title=data.get("title"),
-                selftext=data.get("selftext"),
-                url=data.get("url"),
-                subreddit=data.get("subreddit"),
-                author=data.get("author"),
-                created_utc=created_dt,
-                score=data.get("score", 0),
-                num_comments=data.get("num_comments", 0),
-                sentiment_positive=sentiment.get("pos", 0.0),
-                sentiment_negative=sentiment.get("neg", 0.0),
-                sentiment_neutral=sentiment.get("neu", 0.0),
-                sentiment_compound=sentiment.get("compound", 0.0),
-            )
-            db.session.merge(post)
+# --- HÀM XỬ LÝ STOCKS (MỚI) ---
+def fetch_and_store_stocks(db_session):
+    logging.info("Starting to fetch and store stocks...")
+    stock_fetcher = StockDataFetcher()
+    reddit_fetcher = RedditFetcher()
+    popular_stocks = ['AAPL', 'MSFT', 'GOOG', 'AMZN', 'TSLA', 'META', 'NVDA', 'SPY', 'QQQ', 'AMD']
 
-        try:
-            db.session.commit()
-        except Exception as exc:  # pragma: no cover - logging
-            db.session.rollback()
-            logging.error("Failed to commit posts: %s", exc)
+    for symbol in popular_stocks:
+        company_info = stock_fetcher.get_stock_overview(symbol)
+        price_data = stock_fetcher.get_daily_prices(symbol, days=1)
+        latest_price = price_data[0]["close"] if price_data else None
+        sentiment_data = reddit_fetcher.get_historical_sentiment(symbol, days=7)
+        sentiments = [d.get("sentiment_avg", 0) for d in sentiment_data]
+        avg_sentiment = sum(sentiments) / len(sentiments) if sentiments else 0
 
+        stock = Stock(
+            symbol=symbol, name=company_info.get("name", f"{symbol} Inc."),
+            price=latest_price, sector=company_info.get("sector", "Technology"),
+            sentiment=avg_sentiment
+        )
+        db_session.merge(stock)
+    logging.info(f"Merged {len(popular_stocks)} stocks.")
+
+# --- HÀM CHẠY CHÍNH ---
+def run_job():
+    # Tạo bảng nếu chưa có
+    Base.metadata.create_all(bind=engine)
+    db_session = SessionLocal()
+    try:
+        fetch_and_store_posts(db_session)
+        fetch_and_store_stocks(db_session)
+        db_session.commit()
+        logging.info("Job finished successfully. Data committed.")
+    except Exception as exc:
+        logging.error("Job failed: %s", exc)
+        db_session.rollback()
+    finally:
+        db_session.close()
 
 if __name__ == "__main__":
-    fetch_and_store_posts()
+    run_job()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,8 +1,11 @@
 from app import db
 from datetime import datetime
 
+# Expose the base model for use outside of the Flask context
+Base = db.Model
 
-class Post(db.Model):
+
+class Post(Base):
     id = db.Column(db.String(10), primary_key=True)
     title = db.Column(db.String(300), nullable=False)
     selftext = db.Column(db.Text)
@@ -26,7 +29,7 @@ class Post(db.Model):
         return f'<Post {self.id}: {self.title}>'
 
 
-class Comment(db.Model):
+class Comment(Base):
     id = db.Column(db.String(10), primary_key=True)
     body = db.Column(db.Text, nullable=False)
     author = db.Column(db.String(50))
@@ -50,7 +53,7 @@ class Comment(db.Model):
         return f'<Comment {self.id}>'
 
 
-class SentimentData(db.Model):
+class SentimentData(Base):
     id = db.Column(db.Integer, primary_key=True)
     entity = db.Column(db.String(100), nullable=False, index=True)
     date = db.Column(db.Date, nullable=False)
@@ -74,3 +77,14 @@ class SentimentData(db.Model):
     
     def __repr__(self):
         return f'<SentimentData {self.entity} on {self.date}>'
+
+
+class Stock(Base):
+    symbol = db.Column(db.String(10), primary_key=True)
+    name = db.Column(db.String(100))
+    price = db.Column(db.Float)
+    sector = db.Column(db.String(100))
+    sentiment = db.Column(db.Float)
+
+    def __repr__(self):
+        return f'<Stock {self.symbol}>'


### PR DESCRIPTION
## Summary
- define Stock model and expose SQLAlchemy Base
- rewrite cron_job to persist posts and popular stocks
- serve stocks from database in `/api/stocks`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a775e6907c8330b826623ca59b8c57