### PR TITLE
Refactor lightweight app server and heavy cron job

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,38 +1,20 @@
 import os
-from flask import Flask, request, jsonify
+from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
-try:  # pragma: no cover - support package and script execution
-    from .reddit_fetcher import RedditFetcher
-    from .stock_data_fetcher import StockDataFetcher
-except ImportError:
-    from reddit_fetcher import RedditFetcher
-    from stock_data_fetcher import StockDataFetcher
 
 app = Flask(__name__)
 CORS(app)
 
-# Get DATABASE_URL from environment
+# --- PHẦN CẤU HÌNH DATABASE (GIỮ NGUYÊN) ---
 database_url = os.environ.get('DATABASE_URL')
-
-# Adjust for deprecated postgres scheme
 if database_url and database_url.startswith("postgres://"):
     database_url = database_url.replace("postgres://", "postgresql://", 1)
-
-# Fallback to SQLite if no database is configured. This allows the module to
-# be imported in environments where a database URL hasn't been provided (e.g.,
-# generating data snapshots).
-if not database_url:
-    database_url = 'sqlite:///finsentiment.db'
-
 app.config['SQLALCHEMY_DATABASE_URI'] = database_url
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
 db = SQLAlchemy(app)
 
-reddit_fetcher = RedditFetcher()
-stock_data_fetcher = StockDataFetcher()
-
+# --- IMPORT MODELS SAU KHI KHỞI TẠO db ---
 from models import Post, Stock  # noqa: E402
 
 @app.route('/api/posts')

--- a/backend/cron_job.py
+++ b/backend/cron_job.py
@@ -1,6 +1,9 @@
 import os
 import logging
 from datetime import datetime
+
+import pandas as pd  # noqa: F401
+import nltk  # noqa: F401
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 


### PR DESCRIPTION
## Summary
- Streamline `app.py` to remove fetcher imports and only serve data from DB
- Consolidate heavy dependencies into `cron_job.py` for background processing

## Testing
- `python -m py_compile backend/app.py backend/cron_job.py`


------
https://chatgpt.com/codex/tasks/task_e_68a77e9e6fa883309c86bd2d64fe15b6